### PR TITLE
Fix traceability matrix format when rotating the header row

### DIFF
--- a/src/defaults/formatters.typ
+++ b/src/defaults/formatters.typ
@@ -108,7 +108,7 @@
           inset: auto,
         )[#move(
           dy: displacement,
-        )[#rotate(rotation-angle)[#header]]]
+        )[#rotate(rotation-angle, reflow: true)[#header]]]
       } else if i == 0 {
         // First cell gets no top/left borders
         table.cell(stroke: (


### PR DESCRIPTION
Tells typst to use the bounding box of the rotated text for layout, avoiding the text clipping the table